### PR TITLE
FIX RChain FAQ errors

### DIFF
--- a/developer-rchain-coop/src/views/faq.hbs
+++ b/developer-rchain-coop/src/views/faq.hbs
@@ -16,29 +16,29 @@
         <div class="bodyText"><a href="http://docs.google.com/gview?url=https://github.com/rchain/reference/raw/master/docs/RChainWhitepaper.pdf" target="_blank">On Github (PDF).</a> See also the <a href="http://rchain-architecture.readthedocs.io/" target="_blank">RChain Architecture</a></div>
 
         <div class="subHeader">Where is the roadmap?</div>
-        <div class="bodyText">A roadmap is being worked on, as a result of the Developer Retreat in November. You can see the milestones and dependency graph at: <br><a href="https://rchain.atlassian.net/wiki/spaces/CORE/pages/105709609/The+Flight+to+Mercury" target="_blank">https://rchain.atlassian.net/roadmap</a><br>RChain is an ambitious project, involving research, not just writing code. Dates are not finalized until communicated explicitly.</div>
+        <div class="bodyText">A roadmap is being worked on, as a result of the Developer Retreat in November, 2017. You can see the milestones and dependency graph <a href="https://rchain.atlassian.net/wiki/spaces/CORE/pages/105709609/The+Flight+to+Mercury" target="_blank">here</a>. RChain is an ambitious project, involving research, not just writing code. Dates are not finalized until communicated explicitly.</div>
 
         <div class="subHeader">How did RChain come to be?</div>
-        <div class="bodyText">RChain was the culmination of a number of innovations by founder Greg Meredith. The core of RChain is based on mobile process calculi, a branch of mathematics with approximately 30 years of history. Together with the experience of other blockchains and other technology, the RChain architecture was documented in July of 2016 and at that time, the goal was to create a blockchain-based social network with inbuilt micropayments functionality i.e. attention economy. Due to the complexity of the project and disagreement between the team members, it was decided that Greg would focus on realizing the vision of RChain. The RChain organizations (the <a href="https://www.rchain.coop/" target="_blank">Co-op</a> and <a href="https://www.rchain.io/" target="_blank">Holdings company</a>) were formed in December 2016 - January 2017.</div>
+        <div class="bodyText">RChain was the culmination of a number of innovations by founder Greg Meredith. The core of RChain is based on mobile process calculi, a branch of mathematics with approximately 30 years of history. Together with the experience of other blockchains and other technology, the RChain architecture was documented in July, 2016. At that time, the goal was to create a blockchain-based social network with inbuilt micropayments functionality (i.e. attention economy). Due to the complexity of the project and disagreement between team members, it was decided that Greg would focus on realizing the vision of RChain. The RChain organizations (the <a href="https://www.rchain.coop/" target="_blank">Co-op</a> and Holdings company) were formed in December 2016 - January 2017.</div>
     </div>
 
     <div class="section">
         <div class="header">Cooperative</div>
 
         <div class="subHeader">What is the difference between the Cooperative and the Holdings company?</div>
-        <div class="bodyText">The <a href="https://www.rchain.coop/" target="_blank">Co-op</a> is the organization that develops the open-source RChain platform software. It’s an open and community-driven initiative with multiple communication channels through which all are welcome to participate. <a href="http://rchain.io/" target="_blank">RChain Holdings</a> is a for-profit entity whose mission is to grow the ecosystem around the RChain platform, through incubating startups, forming joint ventures, developing products, and delivering professional services.</div>
+        <div class="bodyText">The <a href="https://www.rchain.coop/" target="_blank">Co-op</a> is the organization that develops the open-source RChain platform software. It’s an open and community-driven initiative with multiple communication channels through which all are welcome to participate. RChain Holdings is a for-profit entity whose mission is to grow the ecosystem around the RChain platform, through incubating startups, forming joint ventures, developing products, and delivering professional services.</div>
 
         <div class="subHeader">Where is RChain based?</div>
         <div class="bodyText">The RChain Cooperative and RChain Holdings are both Internet companies and have participants around the world. They are Washington State USA companies and the founders live in Seattle.</div>
 
         <div class="subHeader">What is the governance model?</div>
-        <div class="bodyText">The Co-op is a member-driven organization with an elected nine-person <a href="https://www.rchain.coop/#team" target="_blank">Board of Directors</a>. Board seats have 3, 2, or 1 year terms. The board is composed of:
+        <div class="bodyText">The Co-op is a member-driven organization with an elected nine-person <a href="https://www.rchain.coop/team" target="_blank">Board of Directors</a>. Board seats have 3, 2, or 1 year terms. The board is composed of:
             <ul>
                 <li>3 years: Greg Meredith, Vlad Zamfir, Ian Bloom</li>
-                <li>2 years: Kenny Rowe, Evan Jensen, Alexander Bulkin</li>
-                <li>1 year: Navneet Suman, Hendrik Jan Hilbolling, David Currin</li>
+                <li>2 years: Kenny Rowe, Evan Jensen</li>
+                <li>1 year: Barry Cynamon, Kevin Goldstein</li>
             </ul>
-            The Co-op officers are: Greg Meredith, President; Evan Jensen, Secretary; Lisa Rice, Treasurer.<br><br> There are three steering committees where Members collaborate to shape and organize the Cooperative: the Executive Committee, the Governance Committee, and the Compensation Committee. All committees have open participation but some are limited to 11 working members plus a chair.
+            The Co-op officers are: Greg Meredith, President; Kenny Rowe, Vice-President<br><br> There are three steering committees where Members collaborate to shape and organize the Cooperative: the Executive Committee, the Governance Committee, and the Compensation Committee. All committees have open participation but some are limited to 11 working members plus a chair.
         </div>
     </div>
 
@@ -58,13 +58,13 @@
         <div class="bodyText">Click “Add Custom Token”, then fill in:<br>Contract Address: 0x168296bb09e24a88805cb9c33356536b980d3fc5<br>Token Symbol: RHOC<br>Decimals: 8</div>
 
         <div class="subHeader">Where can I trade RHOCs?</div>
-        <div class="bodyText">RChain can not endorse RHOC trading because of the structure of our private sale.</div>
+        <div class="bodyText">RChain cannot endorse RHOC trading because of the structure of our private sale.</div>
 
         <div class="subHeader">Is it possible to redeem AMPs for RHOCs?</div>
         <div class="bodyText">Not directly; the redemption period ended in April 2017. AMPs and RHOCs are tradable on exchanges.</div>
 
         <div class="subHeader">What is the process for swapping RHOC for REV?</div>
-        <div class="bodyText">RHOCs will be 1:1 redeemable for REVs. REVs are the native staking token for the RChain platform. <a href="token-swap">Learn more about the RHOC/REV swap.</a></div>
+        <div class="bodyText">RHOCs will be 1:1 redeemable for REVs. REVs are the native staking token for the RChain platform. <a href="token-swap" target="_blank">Learn more about the RHOC/REV swap.</a></div>
     </div>
 
     <div class="section">
@@ -74,29 +74,25 @@
         <div class="bodyText">Join one of the public discussion forums (see the comm channels above). People who want to play a more active role can collaborate on code and community development projects, create Co-op infrastructure, and work out its governance. See <a href="https://github.com/rchain/Members/blob/master/CONTRIBUTING.md" target="_blank">CONTRIBUTING.md</a> for full information.</div>
 
         <div class="subHeader">What is the Membership Program?</div>
-        <div class="bodyText">Interested individuals can become a Member of the Co-op. Benefits include: access to all channels of the Discord server where the RChain developers and community collaborate, electing the board members, participating in governance committees, being eligible to propose and collaborate on projects, and deciding about project approval and budget allocation. Additional benefits will be defined over time such as patronage dividends. Membership requires a one-time $20 membership fee and proof of identity in the form of government issued id and video verification with the Cooperative. If you'd like to join please register at: <a href="https://member.rchain.coop" target="_blank">https://member.rchain.coop</a></div>
+        <div class="bodyText">Interested individuals can become a Member of the Co-op. Benefits include: access to all channels of the Discord server where the RChain developers and community collaborate, electing the board members, participating in governance committees, being eligible to propose and collaborate on projects, and deciding about project approval and budget allocation. Additional benefits will be defined over time such as patronage dividends. Membership requires a one-time $20 membership fee and proof of identity in the form of government-issued ID and video verification with the Cooperative. If you'd like to join please register <a href="https://rchain.coop/community" target="_blank">here</a></div>.
 
         <div class="subHeader">I live outside of the United States. Can I join as a Member?</div>
         <div class="bodyText">Yes, unless you reside in a region sanctioned by the US. The registration process will check that.</div>
 
         <div class="subHeader">Is there a bounty program?</div>
-        <div class="bodyText">Yes. Bounties are task based with peer review. Tasks vary, but typically bounties are available for core development, community formation, marketing, business development, and channel operation. Github is used for <a href="https://github.com/rchain/Members/" target="_blank">issue tracking and project management</a>.</div>
-
-        <div class="subHeader">Can I earn RHOCs by participating in projects?</div>
-        <div class="bodyText">Yes. Read <a href="https://github.com/rchain/Members/blob/master/CONTRIBUTING.md" target="_blank">CONTRIBUTING.md</a>, then look for projects you’d like to participate in.</div>
-    </div>
+        <div class="bodyText">Previously, there was a bounty program. We are looking at reinstating it in 2019.</a>.</div>
 
     <div class="section" style="padding-bottom: 4rem;">
         <div class="header">Developers</div>
 
         <div class="subHeader">What is Pi Calculus?</div>
-        <div class="bodyText">“In theoretical computer science, the π-calculus is a process calculus. The π-calculus allows channel names to be communicated along the channels themselves, and in this way it is able to describe concurrent computations whose network configuration may change during the computation.” (Ref.: <a>https://en.wikipedia.org/wiki/Pi-calculus</a>). To better understand how it is being applied in the RChain development, check out the paper <a href="http://mobile-process-calculi-for-programming-the-new-blockchain.readthedocs.io/en/latest/" target="_blank">Mobile process calculi for programming the blockchain.</a></div>
+        <div class="bodyText">“In theoretical computer science, the π-calculus is a process calculus. The π-calculus allows channel names to be communicated along the channels themselves, and in this way it is able to describe concurrent computations whose network configuration may change during the computation.” (<a href="https://en.wikipedia.org/wiki/Pi-calculus" target="_blank">Reference</a>). To better understand how it is being applied in the RChain development, check out the paper <a href="http://mobile-process-calculi-for-programming-the-new-blockchain.readthedocs.io/en/latest/" target="_blank">Mobile process calculi for programming the blockchain.</a></div>
 
         <div class="subHeader">What skills do I need to participate?</div>
-        <div class="bodyText">At this point the entire development focus is on the core platform. The VM, storage, and networking layers are all written in Scala. There will eventually be code for Casper, the REV wallet, and a few other things in Rholang. If you’re a seasoned developer with Scala skills then please get in touch. Down the road more and varied skills will be needed. Programmers versed in other languages, web developers, designers, Javascript experts, system administrators, beta testers, and quality assurance people will be in demand. If you'd like to participate please <a href="https://member.rchain.coop/" target="_blank">join as a Member</a> and put yourself in the Talent Pool.</div>
+        <div class="bodyText">At this point the entire development focus is on the core platform. The VM, storage, and networking layers are all written in Scala. There will eventually be code for Casper, the REV wallet, and a few other things in Rholang. If you’re a seasoned developer with Scala skills then please get in touch. Down the road more and varied skills will be needed. Programmers versed in other languages, web developers, designers, Javascript experts, system administrators, beta testers, and quality assurance people will be in demand. If you'd like to participate please <a href="https://rchain.coop/community" target="_blank">join as a Member</a> and put yourself in the Talent Pool.</div>
 
         <div class="subHeader">How can I learn Rholang?</div>
-        <div class="bodyText">An understanding of Pi Calculus will help. Join the <a>RChain Discord</a> and inquire to find out more. The <a>RChain YouTube channel</a> has videos that explain various aspects of the platform. Our developer subdomain also hosts a Rholang tutorial which can be found <a href="https://developer.rchain.coop/tutorial">here</a>.</div>
+        <div class="bodyText">An understanding of Pi Calculus will help. Join the RChain Discord and inquire to find out more. The <a href="https://www.youtube.com/channel/UCSS3jCffMiz574_q64Ukj_w" target="_blank">RChain YouTube channel</a> has videos that explain various aspects of the platform. Our developer subdomain also hosts a Rholang tutorial which can be found <a href="https://github.com/JoshOrndorff/LearnRholangByExample#learn-rholang-by-example">here</a>.</div>
 
         <div class="subHeader">What will the license be for RChain's components?</div>
         <div class="bodyText">RChain's components are all under open source and free software licenses. Our license of choice is Apache v2. Rholang is the only component currently licensed under the MIT license.</div>
@@ -105,18 +101,18 @@
         <div class="bodyText">There is a Dapp (Cryptofex) that intends to build an IDE on RChain that can support Rholang and solidity for a start so devs that are familiar with solidity can easily code smart contracts that would run on RChain's VM. The team behind the Dapp is same team leading the RChain's development; Pyrofex. <a href="https://docs.google.com/document/d/18xe2cySKxaKXlyqheY0nzsn9-GyoqALgAITTEeZDD7M/edit" target="_blank">Cryptofex White Paper</a></div>
 
         <div class="subHeader">Tell me more about the storage layer.</div>
-        <div class="bodyText">The storage layer is a fundamental part of the VM; it just happens to be something that's modular enough to break out into its own library. The storage layer is how message delivery between processes is implemented; it uses rholang patterns as keys. Sending on a pattern is putting data in the database; receiving on a pattern is querying the database. If there's no data to consume, a continuation is stored at the key instead. If there's already a continuation, and you're trying to store data, the continuation gets applied to the incoming data.</div>
+        <div class="bodyText">The storage layer is a fundamental part of the VM; it just happens to be something that's modular enough to break out into its own library. The storage layer is how message delivery between processes is implemented; it uses Rholang patterns as keys. Sending on a pattern is putting data in the database; receiving on a pattern is querying the database. If there's no data to consume, a continuation is stored at the key instead. If there's already a continuation, and you're trying to store data, the continuation gets applied to the incoming data.</div>
 
         <div class="subHeader">Where is the data stored? Is all data replicated across all nodes in a namespace?</div>
         <div class="bodyText">We're building an API backed by LMDB (<a>Lightning Memory-Mapped Database</a>). Yes.</div>
 
         <div class="subHeader">What is the process for transaction commitment?</div>
-        <div class="bodyText">Rholang doesn't use a notion of transaction in the same way that ethereum does. Ethereum uses event-loop concurrency, and either the entire turn kicked off by a message succeeds or it doesn't (maybe you ran out of gas, maybe there was some other error). Rholang blocks, on the other hand, contain three kinds of data: individual synchronizations of names, new sends, and new contract deployments. If you want transactions, you have to write code that implements them.</div>
+        <div class="bodyText">Rholang doesn't use a notion of transaction in the same way that Ethereum does. Ethereum uses event-loop concurrency, and either the entire turn kicked off by a message succeeds or it doesn't (maybe you ran out of gas, maybe there was some other error). Rholang blocks, on the other hand, contain three kinds of data: individual synchronizations of names, new sends, and new contract deployments. If you want transactions, you have to write code that implements them.</div>
 
-        <div class="subHeader">Whats the key difference between ETH Casper and Rchain Casper and why bother doing Rchain and not just build on top of Ethereum and Casper?</div>
-        <div class="bodyText">In short, the main reason not to build on top of Ethereum is in order to have formal verification at all levels. i.e. There will always be some math which can prove to us that any given part of the system is bug-free. The foundation of RChain is Reflective Higher Order Calculus, which enables the creation of ‘correct-by-construction’ contracts. From system contracts to Casper Consensus, RChain contracts will be backed by formal verification- giving users some guarantees on what these contracts do.</div>
+        <div class="subHeader">What's the key difference between ETH Casper and Rchain Casper and why bother doing Rchain and not just build on top of Ethereum and Casper?</div>
+        <div class="bodyText">In short, the main reason not to build on top of Ethereum is in order to have formal verification at all levels. i.e. There will always be some math which can prove to us that any given part of the system is bug-free. The foundation of RChain is Reflective Higher Order Calculus, which enables the creation of ‘correct-by-construction’ contracts. From system contracts to Casper Consensus, RChain contracts will be backed by formal verification, giving users some guarantees on what these contracts do.</div>
 
         <div class="subHeader">What is a safety oracle?</div>
-        <div class="bodyText">A safety oracle looks at all the messages a node has received and says "at this point, no one can convince me that this subset of information is wrong". If the network converges on the value of that information, it must converge on what that node believes.</div>
+        <div class="bodyText">A safety oracle looks at all the messages a node has received and says "at this point, no one can convince me that this subset of information is wrong." If the network converges on the value of that information, it must converge on what that node believes.</div>
     </div>
 </div>


### PR DESCRIPTION
Roadmap: cleared up blank space and linked to road map.
RChain come to be: made grammatical fixes; removed dead link
Cooperative/holding: removed dead link
Governance model: fixed dead link to Team; changed board members
Trade RHOCs: fixed grammatical error
Process for swapping: added jump page to link
Membership program: cleaned up link and grammar
Bounty program: currently closed, so changed that verbiage
Earn RHOCs: removed, as there is currently no bounty program
Pi calculus: cleaned up Wiki link
Skills: changed dead link
Learn Rholang: added Youtube link; changed dead link to tutorial
Storage layer: edited grammatical errors
Key difference: edited grammatical errors
Safety oracle: edited grammatical errors