### PR TITLE
FIX RNode v0.8.1 links

### DIFF
--- a/developer-rchain-coop/src/views/index.hbs
+++ b/developer-rchain-coop/src/views/index.hbs
@@ -21,21 +21,20 @@
             <div class="item">
                 <div class="subHeader">RNode</div>
                 <div class="body">Nodes form the RChain peer-to-peer network. The network layer is the lowest level component in the architecture that will eventually support RChain’s large-scale blockchain operations.</div>
-                <div class="title">RNode v0.7.1</div>
-                <div class="body">RNode v0.7.1 (1977b934c9c77024539638ecd9d72e35c9b00048) now offers validator bonding, cost accounting, and a name registry.</div>
-                <a href="https://rchain.atlassian.net/wiki/spaces/CORE/pages/573767736/Release+Notes+-+RNode+v0.7" target="_blank" class="img"><img src="/assets/read.svg">RNode v0.7.1 release Notes</a><br>
+                <div class="title">RNode v0.8.1 (fbd2fc9)</div>
+                <a href="https://rchain.atlassian.net/wiki/spaces/CORE/pages/323387460/RNode-0.8.1+release+plan" target="_blank" class="img"><img src="/assets/read.svg">RNode v0.8.1 release plan</a><br>
                 <a href="https://rchain.atlassian.net/wiki/spaces/CORE/pages/428376065/User+guide+for+running+RNode" target="_blank" class="img"><img src="/assets/read.svg">RNode user guide</a><br>
                 <div class="subSubHeader">Docker</div>
                 <pre>docker pull rchain/rnode</pre>
                 <div class="subSubHeader">Homebrew</div>
                 <pre>brew install rchain/rchain/rnode</pre>
                 <div class="subSubHeader">Packages</div>
-                <a href="https://github.com/rchain/rchain/releases/download/v0.7.1/rnode-0.7.1-1.noarch.rpm"><img src="/assets/download.svg">rnode-0.7.1-1.noarch.rpm</a>
-                <a href="https://github.com/rchain/rchain/releases/download/v0.7.1/rnode-0.7.1.tgz"><img src="/assets/download.svg">rnode-0.7.1.tgz</a>
-                <a href="https://github.com/rchain/rchain/releases/download/v0.7.1/rnode_0.7.1_all.deb"><img src="/assets/download.svg">rnode_0.7.1_all.deb</a>
+                <a href="https://github.com/rchain/rchain/releases/download/v0.8.1/rnode-0.8.1-1.noarch.rpm"><img src="/assets/download.svg">rnode-0.8.1-1.noarch.rpm</a>
+                <a href="https://github.com/rchain/rchain/releases/download/v0.8.1/rnode-0.8.1.tgz"><img src="/assets/download.svg">rnode-0.8.1.tgz</a>
+                <a href="https://github.com/rchain/rchain/releases/download/v0.8.1/rnode_0.8.1_all.deb"><img src="/assets/download.svg">rnode_0.8.1_all.deb</a>
                 <div class="subSubHeader">Source Code</div>
-                <a href="https://github.com/rchain/rchain/archive/v0.7.1.zip" class="subSubHeader-link img"><img src="/assets/download.svg">Source code (zip)</a>
-                <a href="https://github.com/rchain/rchain/archive/v0.7.1.tar.gz" class="subSubHeader-link img"><img src="/assets/download.svg">Source code (tar.gz)</a>
+                <a href="https://github.com/rchain/rchain/archive/v0.8.1.zip" class="subSubHeader-link img"><img src="/assets/download.svg">Source code (zip)</a>
+                <a href="https://github.com/rchain/rchain/archive/v0.8.1.tar.gz" class="subSubHeader-link img"><img src="/assets/download.svg">Source code (tar.gz)</a>
             </div>
             <div class="item">
                 <div class="subHeader">Rholang</div>


### PR DESCRIPTION
1. Change heading to "RNode v0.8.1 (fbd2fc9)"
2. Remove text
3. Remove link to RNode v0.7.1 release notes. Replace with link to RNode v0.8.1 release plan
4. Update links to packages. Find links at https://github.com/rchain/rchain/releases/tag/v0.8.1