### PR TITLE
[FIX] broken links

### DIFF
--- a/rsong/public/index.html
+++ b/rsong/public/index.html
@@ -179,7 +179,7 @@
 
   <section class="bl bw3 b--light-gray pl3 mb6">
      <span class="near-black f4 f3-l fw7 lh-title ph0 mb2 dib">RSONG White Paper</span><br>
-     <a href="https://blog.rchain.coop/wp-content/uploads/2018/10/RSong-whitepaper.pdf" target="_blank" class="near-black f4">Read the white paper</a>
+     <a href="https://blog.rchain.coop/wp-content/uploads/2018/10/RSong-whitepaper.pdf" target="_blank" class="near-black f4">Read the white-paper</a>
   </section>
 
   <section class="bl bw3 b--light-gray pl3 mb6">


### PR DESCRIPTION
rsong.rchain.coop & rsong.org blog links should point to

blog.rchain.coop/...
not rchain.coop/blog/..