### PR TITLE
Remove nav item

### DIFF
--- a/developer-rchain-coop/src/views/layout.hbs
+++ b/developer-rchain-coop/src/views/layout.hbs
@@ -63,9 +63,6 @@
             <a href="/token-swap">REV Issuance</a>
         </div>
         <div class="item" onclick="">
-            <a href="https://forum.rchain.coop" target="_blank">Forum</a>
-        </div>
-        <div class="item" onclick="">
             <a href="https://rchain.coop" target="_blank">Rchain.Coop</a>
         </div>
     </div>


### PR DESCRIPTION
Nav item (FORUM) unnecessary. It points back to developer.rchain.coop