### PR TITLE
FIX - remove KuCoin banner

### DIFF
--- a/rchain-coop/src/views/layout.hbs
+++ b/rchain-coop/src/views/layout.hbs
@@ -40,18 +40,6 @@
 <body>
     <!--  Navbar Start -->
     <header>
-      <p style="
-      text-align: center;
-      padding: 1.65em;
-      background: orange;
-      color: white;
-      margin-top: 2.72em;
-      position: fixed;
-      z-index: 99;
-      display: block;
-      width: 100%;
-      ">⚠ Remember to withdraw your tokens from KUCOIN before 18:00 (UTC+8) on May 8,2020.<br>
-      <a href="https://www.kucoin.com/news/en-kucoin-delisting-of-rhoc-project">After this date, KUCOIN says, "you are deemed to have given up the funds"</a></p>
         <div class="nav" id="nav">
             <div id="navClose" onclick="navClose()">X</div>
             <div class="wrapper">


### PR DESCRIPTION
deadline already passed (18:00 (UTC+8) on May 8,2020)