### PR TITLE
FIX spacing on rchain.coop nav

### DIFF
--- a/rchain-coop/src/views/layout.hbs
+++ b/rchain-coop/src/views/layout.hbs
@@ -53,11 +53,9 @@
                 <div class="item links" onclick="">
                     <a href="/platform">Platform</a>
                 </div>
-    <!-- Replace with Showcase
-                <div class="item links" onclick="">
+                <div class="item links" onclick="" style="display:none">
                     <a href="/portfolio">Portfolio</a>
                 </div>
-    End Replace-->
                 <div class="item links" id="dropdown">
                     <a href="javascript:void(0)">Community<span class="arrow">&rsaquo;</span></a>
                     <div class="dropdown">


### PR DESCRIPTION
Hide Portfolio Nav item rather than comment out. This preserves spacing.
(Thanks to Nuno#0539.)